### PR TITLE
revision: use an import map for the applura client module

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,6 +4,15 @@
     <!-- Meta tags can be configured per-resource using a Metadata resource field. Applura will add them server side. -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Define a source for the "@applura/client" in "src/index.js". -->
+    <script type="importmap">
+      {
+        "imports": {
+          "@applura/client": "https://cdn.applura.com/dist/js/client/v2.js"
+        }
+      }
+    </script>
+    <!-- Preload the official Applura client module for increased performance. -->
     <script
       async
       rel="preload"

--- a/src/index.js
+++ b/src/index.js
@@ -3,25 +3,14 @@ import { createRoot } from "react-dom/client";
 import App from "./app.jsx";
 import Socket from "./component/socket.jsx";
 
-/**
- * ClientURL is the location where the Applura JavaScript module can be downloaded.
- *
- * It is important to import this module dynamically in order for applications to immediately benefit from security and
- * performance improvements. The module at this URL will never contain API-breaking changes. I.e., breaking changes will
- * use new URL (e.g. "…/v3.js"). However, bug fixes and non-breaking changes are deployed continuously.
- */
-const ClientURL = "https://cdn.applura.com/dist/js/client/v2.js";
-
-// Immediately load the latest Applura client. Do not put the dynamic import inside the "DOMContentLoaded" event
-// listener to ensure the import begins as quickly as possible.
-const clientImport = import(ClientURL);
+// The "@applura/client" package identifier is defined by the import map in index.html. It is not published on NPM.
+// See https://github.com/Applura/client#browser-only-import.
+import { bootstrap } from "@applura/client";
 
 // Mount and launch the client-side application.
 document.addEventListener("DOMContentLoaded", async () => {
-  // Wait for the library to complete its import, then bootstrap the Applura client. This should wait for the
-  // "DOMContentLoaded" event since the "bootstrap" function depends on <link> elements in the document <head>. They
-  // provide the URL for the current resource.
-  const { bootstrap } = await clientImport;
+  // Bootstrap the Applura client. This should wait for the "DOMContentLoaded" event since the "bootstrap" function
+  // depends on <link> elements in the document <head>. They provide the URL for the current resource.
   const client = bootstrap();
   // Get the application container.
   const container = document.getElementById("app");

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -28,6 +28,12 @@ module.exports = {
       },
     ],
   },
+  externalsType: "module",
+  externals: {
+    // The "@applura/client" package identifier is defined by the import map in index.html. It is not published on NPM.
+    // See https://github.com/Applura/client#browser-only-import.
+    "@applura/client": "@applura/client",
+  },
   experiments: {
     outputModule: true,
   },


### PR DESCRIPTION
This PR follows the updated installation instructions in [@applura/client#11](https://github.com/Applura/client/pull/11).