### PR TITLE
Update client version to match kernel ouroboros

### DIFF
--- a/src/component/cards/cards.jsx
+++ b/src/component/cards/cards.jsx
@@ -3,8 +3,8 @@ import "./cards.pcss";
 
 const Cards = ({ cards }) => (
   <div className="cards">
-    {cards.data.map(({ id, title, teaserIcon, teaserText, links }) => (
-      <a key={id} href={links.get("canonical").href}>
+    {cards.map(({ id, title, teaserIcon, teaserText, links }) => (
+      <a key={id} href={links.canonical.href}>
         <div className="card">
           <div className={`card-icon ${teaserIcon}`}></div>
           <div className="card-content">

--- a/src/component/cards/cards.jsx
+++ b/src/component/cards/cards.jsx
@@ -1,22 +1,21 @@
 import React from "react";
 import './cards.pcss';
 
-const Cards = ({ cards }) => {
-  return (
-    <div className="cards">
-      {cards.map(({ title, teaserIcon, teaserText, links }, i) => (
-        <a href={links.canonical.href}>
-          <div className="card">
-            <div className={`card-icon ${teaserIcon}`}></div>
-            <div className="card-content">
-              <div className="card-title">{title}</div>
-              <div className="card-description">{teaserText}</div>
-            </div>
+const Cards = ({ cards }) => (
+  <div className="cards">
+    {cards.data.map(({ id, title, teaserIcon, teaserText, links }) => (
+      <a key={id} href={links.get('canonical').href}>
+        <div className="card">
+          <div className={`card-icon ${teaserIcon}`}></div>
+          <div className="card-content">
+            <div className="card-title">{title}</div>
+            <div className="card-description">{teaserText}</div>
           </div>
-        </a>
-      ))}
-    </div>
-  );
-};
+        </div>
+      </a>
+    ))}
+  </div>
+);
+
 
 export default Cards;

--- a/src/component/cards/cards.jsx
+++ b/src/component/cards/cards.jsx
@@ -1,10 +1,10 @@
 import React from "react";
-import './cards.pcss';
+import "./cards.pcss";
 
 const Cards = ({ cards }) => (
   <div className="cards">
     {cards.data.map(({ id, title, teaserIcon, teaserText, links }) => (
-      <a key={id} href={links.get('canonical').href}>
+      <a key={id} href={links.get("canonical").href}>
         <div className="card">
           <div className={`card-icon ${teaserIcon}`}></div>
           <div className="card-content">
@@ -16,6 +16,5 @@ const Cards = ({ cards }) => (
     ))}
   </div>
 );
-
 
 export default Cards;

--- a/src/component/nav/nav.jsx
+++ b/src/component/nav/nav.jsx
@@ -10,7 +10,7 @@ const Nav = ({ menu }) => {
   return (
     <div className="navigation">
       <ul className="menu">
-        {menu.items.map(({ href, title }, i) => (
+        {menu.data.items.map(({ href, title }, i) => (
           <li key={i}><a href={ href }>{ title }</a></li>
         ))}
       </ul>

--- a/src/component/nav/nav.jsx
+++ b/src/component/nav/nav.jsx
@@ -10,7 +10,7 @@ const Nav = ({ menu }) => {
   return (
     <div className="navigation">
       <ul className="menu">
-        {menu.data.items.map(({ href, title }, i) => (
+        {menu.items.map(({ href, title }, i) => (
           <li key={i}>
             <a href={href}>{title}</a>
           </li>

--- a/src/component/nav/nav.jsx
+++ b/src/component/nav/nav.jsx
@@ -11,11 +11,13 @@ const Nav = ({ menu }) => {
     <div className="navigation">
       <ul className="menu">
         {menu.data.items.map(({ href, title }, i) => (
-          <li key={i}><a href={ href }>{ title }</a></li>
+          <li key={i}>
+            <a href={href}>{title}</a>
+          </li>
         ))}
       </ul>
     </div>
-  )
+  );
 };
 
 export default Nav;

--- a/src/component/short-cards/short-cards.jsx
+++ b/src/component/short-cards/short-cards.jsx
@@ -4,26 +4,17 @@ import "./short-cards.pcss";
 /**
  * Nav renders a navigation resource.
  */
-const ShortCards = ({ cards }) => {
-  return (
-    <div className="short-cards">
-      {cards.map(({ id, title, teaserIcon, teaserText, links }, i) => {
-        return (
-          <a
-            key={id}
-            className={`short-card-link`}
-            title={title}
-            href={links.canonical.href}
-          >
-            <div className="short-card">
-              <div className={`short-card-icon ${teaserIcon}`}></div>
-              <div className="short-card-title">{title}</div>
-            </div>
-          </a>
-        );
-      })}
-    </div>
-  );
-};
+const ShortCards = ({ cards }) => (
+  <div className="short-cards">
+    {cards.data.map(({ id, title, teaserIcon, links }) => (
+      <a key={id} className={`short-card-link`} title={title} href={links.get('canonical').href}>
+        <div className="short-card">
+          <div className={`short-card-icon ${teaserIcon}`}></div>
+          <div className="short-card-title">{title}</div>
+        </div>
+      </a>
+    ))}
+  </div>
+);
 
 export default ShortCards;

--- a/src/component/short-cards/short-cards.jsx
+++ b/src/component/short-cards/short-cards.jsx
@@ -7,7 +7,12 @@ import "./short-cards.pcss";
 const ShortCards = ({ cards }) => (
   <div className="short-cards">
     {cards.data.map(({ id, title, teaserIcon, links }) => (
-      <a key={id} className={`short-card-link`} title={title} href={links.get('canonical').href}>
+      <a
+        key={id}
+        className={`short-card-link`}
+        title={title}
+        href={links.get("canonical").href}
+      >
         <div className="short-card">
           <div className={`short-card-icon ${teaserIcon}`}></div>
           <div className="short-card-title">{title}</div>

--- a/src/component/short-cards/short-cards.jsx
+++ b/src/component/short-cards/short-cards.jsx
@@ -6,12 +6,12 @@ import "./short-cards.pcss";
  */
 const ShortCards = ({ cards }) => (
   <div className="short-cards">
-    {cards.data.map(({ id, title, teaserIcon, links }) => (
+    {cards.map(({ id, title, teaserIcon, links }) => (
       <a
         key={id}
         className={`short-card-link`}
         title={title}
-        href={links.get("canonical").href}
+        href={links.canonical.href}
       >
         <div className="short-card">
           <div className={`short-card-icon ${teaserIcon}`}></div>

--- a/src/index.html
+++ b/src/index.html
@@ -8,12 +8,12 @@
     <script type="importmap">
       {
         "imports": {
-          "@applura/client": "https://cdn.applura.com/dist/js/client/v2.js"
+          "@applura/client": "https://cdn.applura.com/dist/js/client/v3.js"
         }
       }
     </script>
     <!-- Preload the official Applura client module for increased performance. -->
-    <link rel="preload" as="script" href="https://cdn.applura.com/dist/js/client/v2.js" crossorigin/>
+    <link rel="preload" as="script" href="https://cdn.applura.com/dist/js/client/v3.js" crossorigin/>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fira+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Jost:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet">

--- a/src/index.html
+++ b/src/index.html
@@ -8,12 +8,12 @@
     <script type="importmap">
       {
         "imports": {
-          "@applura/client": "https://cdn.applura.com/dist/js/client/v3.js"
+          "@applura/client": "https://cdn.applura.com/dist/js/client/v4.js"
         }
       }
     </script>
     <!-- Preload the official Applura client module for increased performance. -->
-    <link rel="preload" as="script" href="https://cdn.applura.com/dist/js/client/v3.js" crossorigin/>
+    <link rel="preload" as="script" href="https://cdn.applura.com/dist/js/client/v4.js" crossorigin/>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Fira+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Jost:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap" rel="stylesheet">

--- a/src/page/basic-page/basic-page.jsx
+++ b/src/page/basic-page/basic-page.jsx
@@ -20,7 +20,7 @@ const BasicPage = ({ fields }) => {
       <Header menu={mainMenu} links={links}></Header>
       <main>
         <section className="basic-page-content">
-          {relatedLinks && relatedLinks.data.length > 0 ? (
+          {relatedLinks && relatedLinks.length > 0 ? (
             <div className="sidebar">
               <div className="sidebar-title">Dive Deeper</div>
               <ShortCards cards={relatedLinks}></ShortCards>

--- a/src/page/basic-page/basic-page.jsx
+++ b/src/page/basic-page/basic-page.jsx
@@ -14,17 +14,16 @@ import "./basic-page.pcss";
 const BasicPage = ({ fields }) => {
   // Extract the required fields from the resource fields.
   const { mainMenu, title, created, relatedLinks, body, links } = fields;
-  const cards = relatedLinks ? Object.values(relatedLinks) : [];
 
   return (
     <div id="basic-page">
       <Header menu={mainMenu} links={links}></Header>
       <main>
         <section className="basic-page-content">
-          {cards && cards.length > 0 ? (
+          {relatedLinks && relatedLinks.data.length > 0 ? (
             <div className="sidebar">
               <div className="sidebar-title">Dive Deeper</div>
-              <ShortCards cards={cards}></ShortCards>
+              <ShortCards cards={relatedLinks}></ShortCards>
             </div>
           ) : null}
           <div className="content">


### PR DESCRIPTION
~~Objects like relatedLinks and menu have a `data` object that contains the actual array.~~
~~This restores the property so that array.map does not throw errors.~~

~~Also, links need to `get` the desired link type, e.g. `myLink.get('canonical')` or it also throws an error.~~

~~Seems like there is an issue with server side rendering however - it's displaying a 500 error in the markup now.~~
~~Maybe a mismatch with the way json is rendered in the SSR vs the client?~~

edit: I originally made fixes to match the use of client.js v2, however the server was using the latest ouroboros which was not present in that build of client. The fix here was to update to a newer client version, then the jsx didn't need any changes. See https://github.com/Applura/client/pull/20